### PR TITLE
chore: add Jira PR sync workflow

### DIFF
--- a/.github/workflows/jira-pr-sync.yml
+++ b/.github/workflows/jira-pr-sync.yml
@@ -1,0 +1,42 @@
+name: Jira PR Sync
+
+on:
+  pull_request:
+    types: [opened, closed, labeled, unlabeled]
+  pull_request_review:
+    types: [submitted, dismissed]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+env:
+  JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
+  JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
+  JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+
+jobs:
+  jira-sync:
+    runs-on: ubuntu-latest
+    if: >-
+      (github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'labeled'))
+      || (github.event_name == 'pull_request' && github.event.action == 'closed')
+      || github.event_name == 'pull_request_review'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Checkout jira-pr-sync
+        uses: actions/checkout@v4
+        with:
+          repository: mta-solutions/jira-pr-sync
+          path: .jira-pr-sync
+
+      - name: Run Jira sync
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const run = require('./.jira-pr-sync/index.js');
+            await run({ github, context, core });


### PR DESCRIPTION
Adds automated GitHub PR ↔ Jira integration.

### What this does
- When a PR title contains a Jira issue tag (like [XYZ-123]), a Jira task is created on that project's board if one exists or on the [SOF board](https://mta-telco.atlassian.net/jira/software/c/projects/SOF/boards/296) if not
- Submitted PR reviews become linked Jira issues
- Merging the PR closes the Jira task; closing without merging cancels it

### Setup
- This automation is centrally defined in the [jira-pr-sync repo](https://github.com/mta-solutions/jira-pr-sync)
- Org-level secrets `JIRA_BASE_URL`, `JIRA_USER_EMAIL`, `JIRA_API_TOKEN` must be set for [mta-solutions](https://github.com/organizations/mta-solutions/settings/secrets/actions).
- The default mapping of GitHub users to Jira emails can be overridden with a local copy of `.github/jira-users.json`